### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -26,10 +26,12 @@ function linkChanged() {
   }
   const links = generateLinks(original);
   for (const link of links) {
+    if (!isSafeHttpUrl(link)) continue;
+    const normalizedLink = new URL(link).href;
     const li = document.createElement("li");
     const a = document.createElement("a");
-    a.setAttribute("href", link);
-    a.innerText = link;
+    a.setAttribute("href", normalizedLink);
+    a.innerText = normalizedLink;
     li.appendChild(a);
     generated.appendChild(li);
   }


### PR DESCRIPTION
Potential fix for [https://github.com/Wissididom/un-at/security/code-scanning/2](https://github.com/Wissididom/un-at/security/code-scanning/2)

Best fix: **validate and canonicalize each generated link immediately before assigning it to `href`, and skip any value that fails strict HTTP(S) validation**. This preserves functionality (still renders valid generated links) while preventing unsafe values from reaching the DOM attribute sink.

In `public/main.js`, inside `linkChanged()` in the loop over `links`, replace direct assignment:

- from: `a.setAttribute("href", link);`
- to: parse/validate each `link` via `new URL(link)` and enforce protocol `http:` or `https:` (using existing `isSafeHttpUrl`), then assign the normalized URL (`parsed.href`) to `href`.
- if invalid, `continue` and do not append that link.

No new dependencies are required. No import changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
